### PR TITLE
Improve config validation and CSV parsing

### DIFF
--- a/app/services/utils/config_manager.py
+++ b/app/services/utils/config_manager.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import copy
 from typing import Dict, Any, List, Optional, Union
 from dataclasses import dataclass, asdict
 from pathlib import Path
@@ -109,6 +110,16 @@ class ProjectConfiguration:
 class ConfigurationManager:
     """Enhanced configuration management system."""
     
+    # Default values for PICO criteria fields
+    PICO_DEFAULTS = {
+        'population': '',
+        'intervention': '',
+        'comparison': '',
+        'outcomes': '',
+        'time_frame': '',
+        'study_types': ''
+    }
+    
     SCHEMA = {
         "type": "object",
         "properties": {
@@ -174,15 +185,7 @@ class ConfigurationManager:
         now = datetime.now().isoformat()
         
         try:
-            pico_defaults = {
-                'population': '',
-                'intervention': '',
-                'comparison': '',
-                'outcomes': '',
-                'time_frame': '',
-                'study_types': ''
-            }
-            pico_kwargs = {**pico_defaults, **pico_data}
+            pico_kwargs = {**self.PICO_DEFAULTS, **pico_data}
             pico = PICOCriteria(**pico_kwargs)
 
             api = APIConfiguration(**api_data)
@@ -242,7 +245,7 @@ class ConfigurationManager:
                 template_data = json.load(f)
 
             # jsonschema validation requires an api_key, but templates omit it
-            temp_validate_data = json.loads(json.dumps(template_data))
+            temp_validate_data = copy.deepcopy(template_data)
             if 'api' in temp_validate_data and 'api_key' not in temp_validate_data['api']:
                 temp_validate_data['api']['api_key'] = 'placeholder'
 
@@ -289,15 +292,7 @@ class ConfigurationManager:
         
         # Additional custom validation
         try:
-            pico_defaults = {
-                'population': '',
-                'intervention': '',
-                'comparison': '',
-                'outcomes': '',
-                'time_frame': '',
-                'study_types': ''
-            }
-            pico_data = {**pico_defaults, **config_dict.get('pico', {})}
+            pico_data = {**self.PICO_DEFAULTS, **config_dict.get('pico', {})}
             pico = PICOCriteria(**pico_data)
             errors.extend(pico.validate())
         except TypeError as e:

--- a/app/services/utils/config_manager.py
+++ b/app/services/utils/config_manager.py
@@ -174,7 +174,17 @@ class ConfigurationManager:
         now = datetime.now().isoformat()
         
         try:
-            pico = PICOCriteria(**pico_data)
+            pico_defaults = {
+                'population': '',
+                'intervention': '',
+                'comparison': '',
+                'outcomes': '',
+                'time_frame': '',
+                'study_types': ''
+            }
+            pico_kwargs = {**pico_defaults, **pico_data}
+            pico = PICOCriteria(**pico_kwargs)
+
             api = APIConfiguration(**api_data)
             processing = ProcessingConfiguration(**processing_data)
             
@@ -196,7 +206,8 @@ class ConfigurationManager:
             return config
             
         except TypeError as e:
-            raise ConfigurationError(f"Invalid configuration data: {e}")
+            # Dataclass construction failed due to missing or invalid fields
+            raise ValidationError(f"Invalid configuration data: {e}")
     
     def save_template(self, config: ProjectConfiguration, template_name: str) -> str:
         """Save configuration as a template."""
@@ -229,10 +240,14 @@ class ConfigurationManager:
         try:
             with open(template_path, 'r') as f:
                 template_data = json.load(f)
-            
-            # Validate against schema
-            jsonschema.validate(template_data, self.SCHEMA)
-            
+
+            # jsonschema validation requires an api_key, but templates omit it
+            temp_validate_data = json.loads(json.dumps(template_data))
+            if 'api' in temp_validate_data and 'api_key' not in temp_validate_data['api']:
+                temp_validate_data['api']['api_key'] = 'placeholder'
+
+            jsonschema.validate(temp_validate_data, self.SCHEMA)
+
             return template_data
             
         except json.JSONDecodeError as e:
@@ -274,7 +289,16 @@ class ConfigurationManager:
         
         # Additional custom validation
         try:
-            pico = PICOCriteria(**config_dict.get('pico', {}))
+            pico_defaults = {
+                'population': '',
+                'intervention': '',
+                'comparison': '',
+                'outcomes': '',
+                'time_frame': '',
+                'study_types': ''
+            }
+            pico_data = {**pico_defaults, **config_dict.get('pico', {})}
+            pico = PICOCriteria(**pico_data)
             errors.extend(pico.validate())
         except TypeError as e:
             errors.append(f"Invalid PICO data: {e}")

--- a/app/services/utils/file_parser.py
+++ b/app/services/utils/file_parser.py
@@ -141,7 +141,7 @@ def parse_csv_file(file_content: str) -> List[Dict]:
     """Parse a CSV file and return a list of study dictionaries."""
     studies = []
     # Accept either file content or a path to a CSV file
-    if os.path.exists(file_content):
+    if "\n" not in file_content and os.path.exists(file_content):
         with open(file_content, "r", encoding="utf-8") as f:
             file_like_object = io.StringIO(f.read())
     else:

--- a/app/services/utils/file_parser.py
+++ b/app/services/utils/file_parser.py
@@ -7,6 +7,7 @@ from lxml import etree
 from Bio import Entrez, Medline
 from typing import List, Dict, Optional, Tuple
 import operator
+import os
 try:
     from nltk.metrics import edit_distance
 except ImportError:
@@ -137,8 +138,15 @@ def parse_tsv_file(file_content: str) -> List[Dict]:
     return studies
 
 def parse_csv_file(file_content: str) -> List[Dict]:
+    """Parse a CSV file and return a list of study dictionaries."""
     studies = []
-    file_like_object = io.StringIO(file_content)
+    # Accept either file content or a path to a CSV file
+    if os.path.exists(file_content):
+        with open(file_content, "r", encoding="utf-8") as f:
+            file_like_object = io.StringIO(f.read())
+    else:
+        file_like_object = io.StringIO(file_content)
+
     reader = csv.DictReader(file_like_object)
     for row in reader:
         authors = row.get("authors", "")

--- a/test_upload_workflow.py
+++ b/test_upload_workflow.py
@@ -6,6 +6,7 @@ Tests file parsing, database integration, and article creation with proper statu
 
 import sys
 import os
+import pytest
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from app.services.utils.file_parser import parse_ris_file, parse_ris_manual, load_studies
@@ -66,6 +67,12 @@ def test_file_parsing():
     
     assert len(all_studies) > 0, "No studies were parsed from the test files"
     return all_studies
+
+
+@pytest.fixture
+def studies():
+    """Fixture that returns parsed studies for database tests."""
+    return test_file_parsing()
 
 def test_database_integration(studies):
     """Test database integration with parsed studies."""


### PR DESCRIPTION
## Summary
- add `os` dependency and handle CSV file paths
- default missing PICO fields when creating configs
- allow templates without API keys
- provide fixture for upload workflow test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f02f2d9bc832998853dff8495c703

## Summary by Sourcery

Improve configuration validation robustness, enhance template and CSV parsing flexibility, and add test fixture for upload workflow

Enhancements:
- Provide default empty strings for missing PICO criteria fields during configuration creation and validation
- Allow loading templates without API keys by making the API field optional in schema validation
- Raise ValidationError instead of ConfigurationError for invalid configuration data
- Import os in the file parser to support CSV file path handling

Tests:
- Add pytest fixture ‘studies’ for reuse of parsed studies in upload workflow tests